### PR TITLE
Add check for API key format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,15 @@
 
 set -ex
 
+shopt -s nocasematch
+
 
 # Check required environment variables
 if [ -z $INPUT_DT_UPLOAD_API_KEY ]; then
   echo "Missing input: DT_UPLOAD_API_KEY"
+  exit 1
+elif [[ ${dt_upload_api_key} =~ APIKey* ]]; then
+  echo "Variable dt_upload_api_key should not start with 'APIKey'"
   exit 1
 fi
 


### PR DESCRIPTION
Make sure that to sent an appropriate error if the customers prefixes his API key with "APIKey ..."