### PR TITLE
Add POLLING_TIMEOUT configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ jobs:
           EXTERNAL_ID: "App_12230045"
           BLOCK_ON_SEVERITY: "HIGH"  # Optional: Block build on high severity vulnerabilities
           WARN_ON_SEVERITY: "MEDIUM"  # Optional: Warn on medium severity vulnerabilities
-          POLLING_TIMEOUT: 300000  # Optional: Stop polling the scan result after the specified time 
+          POLLING_TIMEOUT: 300000  # Optional: Stop polling the scan result after the specified time
 
 ```

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ When `WARN_ON_SEVERITY` is specified, the action will:
 - `LOW`: Block on all severity vulnerabilities (low, medium, high)
 
 ### `POLLING_TIMEOUT`
-When `POLLING_TIMEOUT` is specified, the action will stop polling the scan result after the specified time (milliseconds).
-Defaults to 300 000ms (5 minutes).
+When `POLLING_TIMEOUT` is specified, the action will stop polling the scan result after the specified time in seconds.
+Defaults to 300 seconds (5 minutes).
 
 
 ### Example with Vulnerability Blocking
@@ -135,6 +135,6 @@ jobs:
           EXTERNAL_ID: "App_12230045"
           BLOCK_ON_SEVERITY: "HIGH"  # Optional: Block build on high severity vulnerabilities
           WARN_ON_SEVERITY: "MEDIUM"  # Optional: Warn on medium severity vulnerabilities
-          POLLING_TIMEOUT: 300000  # Optional: Stop polling the scan result after the specified time 
+          POLLING_TIMEOUT: 300  # Optional: Stop polling the scan result after the specified time 
 
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ When `WARN_ON_SEVERITY` is specified, the action will:
 - `MEDIUM`: Block on medium and high severity vulnerabilities  
 - `LOW`: Block on all severity vulnerabilities (low, medium, high)
 
+### `POLLING_TIMEOUT`
+When `POLLING_TIMEOUT` is specified, the action will stop polling the scan result after the specified time (milliseconds).
+Defaults to 300 000ms (5 minutes).
+
+
 ### Example with Vulnerability Blocking
 ```yaml
 - name: Upload to Data Theorem with blocking if high or medium vulnerabilities are found
@@ -130,5 +135,6 @@ jobs:
           EXTERNAL_ID: "App_12230045"
           BLOCK_ON_SEVERITY: "HIGH"  # Optional: Block build on high severity vulnerabilities
           WARN_ON_SEVERITY: "MEDIUM"  # Optional: Warn on medium severity vulnerabilities
+          POLLING_TIMEOUT: 300000  # Optional: Stop polling the scan result after the specified time
 
 ```

--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ jobs:
           EXTERNAL_ID: "App_12230045"
           BLOCK_ON_SEVERITY: "HIGH"  # Optional: Block build on high severity vulnerabilities
           WARN_ON_SEVERITY: "MEDIUM"  # Optional: Warn on medium severity vulnerabilities
-          POLLING_TIMEOUT: 300000  # Optional: Stop polling the scan result after the specified time
+          POLLING_TIMEOUT: 300000  # Optional: Stop polling the scan result after the specified time 
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
     required: false
   POLLING_TIMEOUT:
     description: >
-      Stop polling the scan result after the specified time in milliseconds, default is 5 minutes.
+      Stop polling the scan result after the specified time in seconds, default is 5 minutes.
     required: false
 runs:
   using: 'node20'

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,7 @@ inputs:
   POLLING_TIMEOUT:
     description: >
       Stop polling the scan result after the specified time in milliseconds, default is 5 minutes.
+    required: false
 runs:
   using: 'node20'
   main: 'main.js'

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,9 @@ inputs:
       Valid values: HIGH, MEDIUM, LOW. If not specified, no warnings will be shown.
       This requires a Data Theorem Mobile Results API Key to be set.
     required: false
+  POLLING_TIMEOUT:
+    description: >
+      Stop polling the scan result after the specified time in milliseconds, default is 5 minutes.
 runs:
   using: 'node20'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -112,8 +112,8 @@ function run() {
             if (isNaN(parsed_polling_timeout)) {
                 throw new Error("POLLING_TIMEOUT must be a number");
             }
-            if (parsed_polling_timeout < 0) {
-                throw new Error("POLLING_TIMEOUT must be greater or equal to 0");
+            if (parsed_polling_timeout <= 0) {
+                throw new Error("POLLING_TIMEOUT must be greater than 0");
             }
         }
         // Validate severity levels

--- a/main.js
+++ b/main.js
@@ -291,7 +291,7 @@ function run() {
                         continue;
                     }
                     const status_data = yield status_response.json();
-                    const scan_status = status_data.status || status_data.static_scan.status;
+                    const scan_status = status_data.static_scan.status || status_data.status;
                     if (scan_status &&
                         ["FAILED", "SCAN_ATTEMPT_ERROR", "CANCELLED"].includes(scan_status)) {
                         console.log(`Scan ${scan_id} failed, skipping vulnerability check`);

--- a/main.js
+++ b/main.js
@@ -105,6 +105,7 @@ function run() {
         const external_id = core.getInput("EXTERNAL_ID");
         const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
         const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
+        const polling_timeout = core.getInput("POLLING_TIMEOUT");
         // Validate severity levels
         if (block_on_severity &&
             !["HIGH", "MEDIUM", "LOW"].includes(block_on_severity.toUpperCase())) {
@@ -259,8 +260,15 @@ function run() {
         }
         for (const scan of scan_info) {
             const { mobile_app_id, scan_id } = scan;
-            // Poll for scan completion with 30-second intervals
-            const maxWaitTime = 300000; // 5 minutes
+            var maxWaitTime = 300000; // 5 minutes
+            if (polling_timeout) {
+                maxWaitTime = parseInt(polling_timeout, 10);
+                // Fallback to default value if the value is incorrect
+                if (isNaN(maxWaitTime)) {
+                    maxWaitTime = 300000;
+                }
+            }
+            // Poll for scan completion with 23-second intervals
             const pollInterval = 23000; // 23 seconds
             const startTime = Date.now();
             console.log(`Waiting for scan ${scan_id} to complete...`);

--- a/main.js
+++ b/main.js
@@ -267,6 +267,7 @@ function run() {
                 if (isNaN(maxWaitTime)) {
                     maxWaitTime = 300000;
                 }
+                console.log("Custom polling timeout set: " + polling_timeout);
             }
             // Poll for scan completion with 23-second intervals
             const pollInterval = 23000; // 23 seconds

--- a/main.js
+++ b/main.js
@@ -106,6 +106,14 @@ function run() {
         const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
         const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
         const polling_timeout = core.getInput("POLLING_TIMEOUT");
+        if (polling_timeout) {
+            maxWaitTime = parseInt(polling_timeout, 10);
+            // Fallback to default value if the value is incorrect
+            if (isNaN(maxWaitTime)) {
+                maxWaitTime = 300000;
+            }
+            console.log("Custom polling timeout set: " + polling_timeout);
+        }
         // Validate severity levels
         if (block_on_severity &&
             !["HIGH", "MEDIUM", "LOW"].includes(block_on_severity.toUpperCase())) {

--- a/main.js
+++ b/main.js
@@ -106,14 +106,6 @@ function run() {
         const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
         const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
         const polling_timeout = core.getInput("POLLING_TIMEOUT");
-        if (polling_timeout) {
-            maxWaitTime = parseInt(polling_timeout, 10);
-            // Fallback to default value if the value is incorrect
-            if (isNaN(maxWaitTime)) {
-                maxWaitTime = 300000;
-            }
-            console.log("Custom polling timeout set: " + polling_timeout);
-        }
         // Validate severity levels
         if (block_on_severity &&
             !["HIGH", "MEDIUM", "LOW"].includes(block_on_severity.toUpperCase())) {
@@ -275,7 +267,6 @@ function run() {
                 if (isNaN(maxWaitTime)) {
                     maxWaitTime = 300000;
                 }
-                console.log("Custom polling timeout set: " + polling_timeout);
             }
             // Poll for scan completion with 23-second intervals
             const pollInterval = 23000; // 23 seconds

--- a/main.ts
+++ b/main.ts
@@ -125,6 +125,7 @@ async function run() {
   const external_id = core.getInput("EXTERNAL_ID");
   const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
   const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
+  const polling_timeout = core.getInput("POLLING_TIMEOUT");
 
   // Validate severity levels
   if (
@@ -317,8 +318,16 @@ async function run() {
   for (const scan of scan_info) {
     const { mobile_app_id, scan_id } = scan;
 
-    // Poll for scan completion with 30-second intervals
-    const maxWaitTime = 300000; // 5 minutes
+    var maxWaitTime = 300000; // 5 minutes
+    if (polling_timeout) {
+        maxWaitTime = parseInt(polling_timeout, 10);
+        // Fallback to default value if the value is incorrect
+        if (isNaN(maxWaitTime)) {
+            maxWaitTime = 300000;
+        }
+    }
+
+    // Poll for scan completion with 23-second intervals
     const pollInterval = 23000; // 23 seconds
     const startTime = Date.now();
 

--- a/main.ts
+++ b/main.ts
@@ -126,7 +126,14 @@ async function run() {
   const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
   const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
   const polling_timeout = core.getInput("POLLING_TIMEOUT");
-
+  if (polling_timeout) {
+    maxWaitTime = parseInt(polling_timeout, 10);
+    // Fallback to default value if the value is incorrect
+    if (isNaN(maxWaitTime)) {
+        maxWaitTime = 300000;
+    }
+    console.log("Custom polling timeout set: " + polling_timeout);
+  }
   // Validate severity levels
   if (
     block_on_severity &&

--- a/main.ts
+++ b/main.ts
@@ -363,7 +363,7 @@ async function run() {
         }
 
         const status_data = await status_response.json();
-        const scan_status = status_data.status || status_data.static_scan.status;
+        const scan_status = status_data.static_scan.status || status_data.status;
         if (
           scan_status &&
           ["FAILED", "SCAN_ATTEMPT_ERROR", "CANCELLED"].includes(scan_status)

--- a/main.ts
+++ b/main.ts
@@ -325,6 +325,7 @@ async function run() {
         if (isNaN(maxWaitTime)) {
             maxWaitTime = 300000;
         }
+        console.log("Custom polling timeout set: " + polling_timeout);
     }
 
     // Poll for scan completion with 23-second intervals

--- a/main.ts
+++ b/main.ts
@@ -132,8 +132,8 @@ async function run() {
         if (isNaN(parsed_polling_timeout)) {
             throw new Error("POLLING_TIMEOUT must be a number");
         }
-        if (parsed_polling_timeout < 0) {
-            throw new Error("POLLING_TIMEOUT must be greater or equal to 0");
+        if (parsed_polling_timeout <= 0) {
+            throw new Error("POLLING_TIMEOUT must be greater than 0");
         }
     }
 

--- a/main.ts
+++ b/main.ts
@@ -126,6 +126,17 @@ async function run() {
   const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
   const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
   const polling_timeout = core.getInput("POLLING_TIMEOUT");
+  var parsed_polling_timeout;
+  if (polling_timeout) {
+        parsed_polling_timeout = parseInt(polling_timeout, 10);
+        if (isNaN(parsed_polling_timeout)) {
+            throw new Error("POLLING_TIMEOUT must be a number");
+        }
+        if (parsed_polling_timeout < 0) {
+            throw new Error("POLLING_TIMEOUT must be greater or equal to 0");
+        }
+    }
+
   // Validate severity levels
   if (
     block_on_severity &&
@@ -318,12 +329,8 @@ async function run() {
     const { mobile_app_id, scan_id } = scan;
 
     var maxWaitTime = 300000; // 5 minutes
-    if (polling_timeout) {
-        maxWaitTime = parseInt(polling_timeout, 10);
-        // Fallback to default value if the value is incorrect
-        if (isNaN(maxWaitTime)) {
-            maxWaitTime = 300000;
-        }
+    if (parsed_polling_timeout) {
+        maxWaitTime = parsed_polling_timeout * 1000;
     }
 
     // Poll for scan completion with 23-second intervals
@@ -356,10 +363,10 @@ async function run() {
         }
 
         const status_data = await status_response.json();
-
+        const scan_status = status_data.status || status_data.static_scan.status;
         if (
-          status_data.static_scan &&
-          status_data.static_scan.status === "FAILED"
+          scan_status &&
+          ["FAILED", "SCAN_ATTEMPT_ERROR", "CANCELLED"].includes(scan_status)
         ) {
           console.log(`Scan ${scan_id} failed, skipping vulnerability check`);
           break;

--- a/main.ts
+++ b/main.ts
@@ -126,14 +126,6 @@ async function run() {
   const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
   const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
   const polling_timeout = core.getInput("POLLING_TIMEOUT");
-  if (polling_timeout) {
-    maxWaitTime = parseInt(polling_timeout, 10);
-    // Fallback to default value if the value is incorrect
-    if (isNaN(maxWaitTime)) {
-        maxWaitTime = 300000;
-    }
-    console.log("Custom polling timeout set: " + polling_timeout);
-  }
   // Validate severity levels
   if (
     block_on_severity &&
@@ -332,7 +324,6 @@ async function run() {
         if (isNaN(maxWaitTime)) {
             maxWaitTime = 300000;
         }
-        console.log("Custom polling timeout set: " + polling_timeout);
     }
 
     // Poll for scan completion with 23-second intervals


### PR DESCRIPTION
This pull request introduces a configurable timeout for polling scan results, allowing users to control how long the plugin waits for scans to complete before proceeding. 

Configuration and documentation updates:

Added a new POLLING_TIMEOUT parameter to the action configuration in action.yml, defaulting to 300 seconds (5 minutes).
Updated the README.md to document the POLLING_TIMEOUT parameter, including its purpose, default value. Also clarified the build blocking step to reflect the configurable timeout. 

Command logic changes:

Updated main.js to use the POLLING_TIMEOUT environment variable (with a default of 300 seconds) for scan polling, replacing the previously hardcoded timeout value.

<img width="707" height="552" alt="image" src="https://github.com/user-attachments/assets/3fa7770c-5574-4d42-9674-8dfa4aaab679" />
