### PR TITLE
By default, wait for DAST results when checking the scan status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,10 @@ inputs:
     description: >
       Stop polling the scan result after the specified time in seconds, default is 5 minutes.
     required: false
+  WAIT_FOR_STATIC_SCAN_ONLY:
+    description: >
+      When enabled, waits for the static_scan to be COMPLETED instead of the top-level scan. Default is false.
+    required: false
 runs:
   using: 'node20'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -89,7 +89,6 @@ function check_severity_findings(dt_results_api_key, mobile_app_id, results_sinc
     });
 }
 function run() {
-    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         // Get inputs
         // Mandatory
@@ -292,15 +291,14 @@ function run() {
                         continue;
                     }
                     const status_data = yield status_response.json();
-                    const scan_status = ((_a = status_data.static_scan) === null || _a === void 0 ? void 0 : _a.status) || status_data.status;
+                    const scan_status = status_data.status;
                     if (scan_status &&
                         ["FAILED", "SCAN_ATTEMPT_ERROR", "CANCELLED"].includes(scan_status)) {
                         console.log(`Scan ${scan_id} failed, skipping vulnerability check`);
                         break;
                     }
-                    if (!status_data.static_scan ||
-                        status_data.static_scan.status !== "COMPLETED") {
-                        console.log(`Scan ${scan_id} still in progress, waiting...`);
+                    if (scan_status !== "COMPLETED") {
+                        console.log(`Scan ${scan_id} still in progress (current status: ${scan_status}), waiting...`);
                         yield new Promise((resolve) => setTimeout(resolve, pollInterval));
                         continue;
                     }

--- a/main.js
+++ b/main.js
@@ -270,6 +270,9 @@ function run() {
         if (warn_on_severity) {
             console.log(`Warning on vulnerabilities with minimum severity: ${warn_on_severity}`);
         }
+        if (wait_for_static_scan_only === 'true') {
+            console.log('WAIT_FOR_STATIC_SCAN_ONLY is enabled: will wait for static_scan completion');
+        }
         for (const scan of scan_info) {
             const { mobile_app_id, scan_id } = scan;
             var maxWaitTime = 300000; // 5 minutes

--- a/main.ts
+++ b/main.ts
@@ -126,6 +126,7 @@ async function run() {
   const block_on_severity = core.getInput("BLOCK_ON_SEVERITY");
   const warn_on_severity = core.getInput("WARN_ON_SEVERITY");
   const polling_timeout = core.getInput("POLLING_TIMEOUT");
+  const wait_for_static_scan_only = core.getInput("WAIT_FOR_STATIC_SCAN_ONLY");
   var parsed_polling_timeout;
   if (polling_timeout) {
         parsed_polling_timeout = parseInt(polling_timeout, 10);
@@ -363,7 +364,18 @@ async function run() {
         }
 
         const status_data = await status_response.json();
-        const scan_status = status_data.status;
+        // Check status based on WAIT_FOR_STATIC_SCAN_ONLY parameter
+        let scan_status;
+        if (wait_for_static_scan_only === 'true') {
+          if (status_data.static_scan?.status) {
+            scan_status = status_data.static_scan.status;
+          } else {
+            console.log(`static_scan field not available for scan ${scan_id}, falling back to overall scan status`);
+            scan_status = status_data.status;
+          }
+        } else {
+          scan_status = status_data.status;
+        }
 
         if (
           scan_status &&

--- a/main.ts
+++ b/main.ts
@@ -326,6 +326,10 @@ async function run() {
     );
   }
 
+  if (wait_for_static_scan_only === 'true') {
+    console.log('WAIT_FOR_STATIC_SCAN_ONLY is enabled: will wait for static_scan completion');
+  }
+
   for (const scan of scan_info) {
     const { mobile_app_id, scan_id } = scan;
 

--- a/main.ts
+++ b/main.ts
@@ -363,7 +363,8 @@ async function run() {
         }
 
         const status_data = await status_response.json();
-        const scan_status = status_data.static_scan?.status || status_data.status;
+        const scan_status = status_data.status;
+
         if (
           scan_status &&
           ["FAILED", "SCAN_ATTEMPT_ERROR", "CANCELLED"].includes(scan_status)
@@ -372,11 +373,8 @@ async function run() {
           break;
         }
 
-        if (
-          !status_data.static_scan ||
-          status_data.static_scan.status !== "COMPLETED"
-        ) {
-          console.log(`Scan ${scan_id} still in progress, waiting...`);
+        if (scan_status !== "COMPLETED") {
+          console.log(`Scan ${scan_id} still in progress (current status: ${scan_status}), waiting...`);
           await new Promise((resolve) => setTimeout(resolve, pollInterval));
           continue;
         }


### PR DESCRIPTION
This pull request introduces a new input parameter to the GitHub Action that allows users to control whether the workflow waits for the static scan to complete or for the overall scan status. The implementation updates both the TypeScript and JavaScript versions of the action to respect this new parameter, providing more flexibility in scan result polling.

**New feature: Configurable scan completion behavior**

* Added a new input parameter `WAIT_FOR_STATIC_SCAN_ONLY` to `action.yml`, allowing users to specify if the action should wait for the static scan to complete instead of the top-level scan.

**Implementation in code:**

* Updated both `main.ts` and `main.js` to read the `WAIT_FOR_STATIC_SCAN_ONLY` input and adjust the polling logic accordingly, checking either the `static_scan.status` or the overall `status` based on the parameter. [[1]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R129) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR110)
* Modified the scan status check in `main.ts` and `main.js` to use the new logic, including a fallback to overall scan status if the `static_scan` field is unavailable, and improved logging for clarity. [[1]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L366-R379) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL295-R316)
* Simplified the scan-in-progress check to use the selected `scan_status` and enhanced the progress log message to include the current status. [[1]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L375-R389) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL295-R316)