### PR TITLE
feat: Add SEVERITY_CHECK_SCOPE parameter to control the blocking scope

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,16 @@ inputs:
     description: >
       When enabled, waits for the static_scan to be COMPLETED instead of the top-level scan. Default is false.
     required: false
+  SEVERITY_CHECK_SCOPE:
+    description: >
+      Controls whether BLOCK_ON_SEVERITY and WARN_ON_SEVERITY check only findings
+      from the current scan or all open findings in the mobile app.
+      Valid values: CURRENT_SCAN, ALL_ISSUES
+      - CURRENT_SCAN: Check only findings discovered in the current scan (default)
+      - ALL_ISSUES: Check all open findings associated with the mobile app
+      Default: CURRENT_SCAN
+    required: false
+    default: 'CURRENT_SCAN'
 runs:
   using: 'node20'
   main: 'main.js'


### PR DESCRIPTION
This pull request introduces a new configuration option to control the scope of severity checks for security findings in mobile app scans. It allows users to specify whether severity checks should consider only findings from the current scan or all open findings for the app. The implementation includes updates to both the workflow input and the logic for checking findings, ensuring clearer reporting and validation.

**New severity check scope feature:**

* Added a new input parameter `SEVERITY_CHECK_SCOPE` to `action.yml`, allowing users to choose between checking only the current scan (`CURRENT_SCAN`, default) or all open findings (`ALL_ISSUES`).
* Updated the main logic in `main.js` and `main.ts` to pass the new `SEVERITY_CHECK_SCOPE` parameter through severity check functions, and to use it to determine whether to include findings only from the current scan or from all open issues. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL64-R66) [[2]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R74) [[3]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR78-R81) [[4]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R89-R96)

**Input validation and reporting improvements:**

* Added input validation to ensure `SEVERITY_CHECK_SCOPE` is set to either `CURRENT_SCAN` or `ALL_ISSUES`, with clear error messages for invalid values. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR135-R137) [[2]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R162-R164)
* Improved log and error messages to clarify whether findings are being reported for the current scan or for all open issues, making the output more informative for users. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL333-R353) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL349-R375) [[3]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R428-R448) [[4]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R466-R484)

**Supporting changes:**

* Refactored the handling of the `results_since` parameter to ensure it is only included when appropriate, based on the selected scope. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL48-R52) [[2]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L42-R54)
* Updated the retrieval of the `SEVERITY_CHECK_SCOPE` input in the main workflow logic. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR115) [[2]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R137)